### PR TITLE
Update gcc-wrapper.py to disable interpret_warning

### DIFF
--- a/scripts/gcc-wrapper.py
+++ b/scripts/gcc-wrapper.py
@@ -102,7 +102,7 @@ def run_gcc():
         proc = subprocess.Popen(args, stderr=subprocess.PIPE, env=env)
         for line in proc.stderr:
             print (line.decode("utf-8"), end="")
-            interpret_warning(line.decode("utf-8"))
+            #interpret_warning(line.decode("utf-8"))
         if do_exit:
             sys.exit(1)
 


### PR DESCRIPTION
https://github.com/Joshua-Riek/ubuntu-rockchip/issues/553