### PR TITLE
drivers: drm: dw-hdmi-qp: Stop compute-N spamming kernel logs

### DIFF
--- a/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
+++ b/drivers/gpu/drm/bridge/synopsys/dw-hdmi-qp.c
@@ -545,8 +545,8 @@ static unsigned int hdmi_find_n(struct dw_hdmi_qp *hdmi, unsigned long pixel_clk
 	if (n > 0)
 		return n;
 
-	dev_warn(hdmi->dev, "Rate %lu missing; compute N dynamically\n",
-		 pixel_clk);
+	dev_dbg(hdmi->dev, "Rate %lu missing; compute N dynamically\n",
+		pixel_clk);
 
 	return hdmi_compute_n(hdmi, pixel_clk, sample_rate);
 }


### PR DESCRIPTION
@Joshua-Riek Stop the following device warning on certain monitors.
```
[24073.665748] dwhdmi-rockchip fde80000.hdmi: Rate 241500000 missing; compute N dynamically
```

![Screenshot from 2024-03-02 17-12-59](https://github.com/Joshua-Riek/linux-rockchip/assets/14953024/16f2b812-e3a3-4e1a-ba52-65df066d90a8)
