### PR TITLE
rock5b + mcp251x: Updates and device tree overlay

### DIFF
--- a/arch/arm64/boot/dts/rockchip/overlay/Makefile
+++ b/arch/arm64/boot/dts/rockchip/overlay/Makefile
@@ -194,6 +194,7 @@ dtbo-$(CONFIG_ARCH_ROCKCHIP) += \
 	rk3588-spi0-m1-cs0-spidev.dtbo \
 	rk3588-spi0-m1-cs1-spidev.dtbo \
 	rk3588-spi0-m2-cs0-cs1-spidev.dtbo \
+	rk3588-spi0-m2-cs0-mcp2515-8mhz.dtbo \
 	rk3588-spi0-m2-cs0-spidev.dtbo \
 	rk3588-spi0-m2-cs1-spidev.dtbo \
 	rk3588-spi1-m1-cs0-spidev.dtbo \

--- a/arch/arm64/boot/dts/rockchip/overlay/rk3588-spi0-m2-cs0-mcp2515-8mhz.dts
+++ b/arch/arm64/boot/dts/rockchip/overlay/rk3588-spi0-m2-cs0-mcp2515-8mhz.dts
@@ -1,0 +1,58 @@
+/dts-v1/;
+/plugin/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/pinctrl/rockchip.h>
+#include <dt-bindings/interrupt-controller/irq.h>
+
+/ {
+	metadata {
+		title = "Enable MCP2515 with 8MHz external clock on SPI0-M2 over CS0";
+		compatible = "radxa,rock-5b", "radxa,rock-5b-plus", "radxa,nx5-io", "radxa,cm5-rpi-cm4-io";
+		category = "misc";
+		exclusive = "GPIO1_B2", "GPIO1_B1", "GPIO1_B3", "GPIO1_B4", "GPIO1_B5";
+		description = "Provide support for Microchip MCP2515 SPI CAN controller.\nAssumes 8MHz external clock.\nUses Pin 26 (GPIO1_B5) for INT.";
+	};
+};
+
+&spi0 {
+	status = "okay";
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0m2_pins &spi0m2_cs0>;
+	#address-cells = <1>;
+	#size-cells = <0>;
+	max-freq = <1000000>;
+
+	can0: mcp2515@0 {
+		status = "okay";
+		compatible = "microchip,mcp2515";
+		reg = <0>;
+		spi-max-frequency = <1000000>;
+
+		pinctrl-names = "default";
+		pinctrl-0 = <&mcp2515_int_pins>;
+
+		interrupt-parent = <&gpio1>;
+		interrupts = <RK_PB5 IRQ_TYPE_EDGE_FALLING>;
+
+		clocks = <&can0_osc>;
+		vdd-supply = <&vcc_3v3_s3>;
+		xceiver-supply = <&vcc_3v3_s3>;
+	};
+};
+
+&pinctrl {
+	mcp2515 {
+		mcp2515_int_pins: mcp2515-int-pins {
+			rockchip,pins = <1 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>;
+		};
+	};
+};
+
+&{/} {
+	can0_osc: can0-osc {
+		compatible = "fixed-clock";
+		#clock-cells = <0>;
+		clock-frequency  = <8000000>;
+	};
+};

--- a/drivers/net/can/spi/mcp251x.c
+++ b/drivers/net/can/spi/mcp251x.c
@@ -752,7 +752,7 @@ static int mcp251x_hw_wake(struct spi_device *spi)
 	int ret;
 
 	/* Force wakeup interrupt to wake device, but don't execute IST */
-	disable_irq(spi->irq);
+	disable_irq_nosync(spi->irq);
 	mcp251x_write_2regs(spi, CANINTE, CANINTE_WAKIE, CANINTF_WAKIF);
 
 	/* Wait for oscillator startup timer after wake up */

--- a/drivers/net/can/spi/mcp251x.c
+++ b/drivers/net/can/spi/mcp251x.c
@@ -1300,7 +1300,6 @@ MODULE_DEVICE_TABLE(spi, mcp251x_id_table);
 
 static int mcp251x_can_probe(struct spi_device *spi)
 {
-	const void *match = device_get_match_data(&spi->dev);
 	struct net_device *net;
 	struct mcp251x_priv *priv;
 	struct clk *clk;
@@ -1338,10 +1337,7 @@ static int mcp251x_can_probe(struct spi_device *spi)
 	priv->can.clock.freq = freq / 2;
 	priv->can.ctrlmode_supported = CAN_CTRLMODE_3_SAMPLES |
 		CAN_CTRLMODE_LOOPBACK | CAN_CTRLMODE_LISTENONLY;
-	if (match)
-		priv->model = (enum mcp251x_model)(uintptr_t)match;
-	else
-		priv->model = spi_get_device_id(spi)->driver_data;
+	priv->model = (enum mcp251x_model)(uintptr_t)spi_get_device_match_data(spi);
 	priv->net = net;
 	priv->clk = clk;
 

--- a/drivers/net/can/spi/mcp251x.c
+++ b/drivers/net/can/spi/mcp251x.c
@@ -28,7 +28,6 @@
 #include <linux/device.h>
 #include <linux/ethtool.h>
 #include <linux/freezer.h>
-#include <linux/gpio.h>
 #include <linux/gpio/driver.h>
 #include <linux/interrupt.h>
 #include <linux/io.h>
@@ -482,9 +481,9 @@ static int mcp251x_gpio_get_direction(struct gpio_chip *chip,
 				      unsigned int offset)
 {
 	if (mcp251x_gpio_is_input(offset))
-		return GPIOF_DIR_IN;
+		return GPIO_LINE_DIRECTION_IN;
 
-	return GPIOF_DIR_OUT;
+	return GPIO_LINE_DIRECTION_OUT;
 }
 
 static int mcp251x_gpio_get(struct gpio_chip *chip, unsigned int offset)


### PR DESCRIPTION
This PR is a response to https://github.com/Joshua-Riek/ubuntu-rockchip/issues/1054. It includes
- the device tree overlay for mcp2515 on spi0-m2-cs0 [from Radxa's original (archived) repo](https://github.com/radxa/overlays/blob/56dabd510fef878cd3a1320cf8d7dcbf493b2524/arch/arm64/boot/dts/rockchip/overlays/rk3588-spi0-m2-cs0-mcp2515-8mhz.dts)
- all fixes to the driver itself that are currently in the upstream master, including a fix for [CVE-2024-46791](https://lore.kernel.org/linux-cve-announce/2024091853-CVE-2024-46791-af66@gregkh/T/).

Unfortunately, i was not able to test this as thoroughly as I'd like; We're still having some reliability and data integrity issues, but that might as well be a hardware issue on our side, since we were having those with the original Radxa kernel as well.

However, I'm submitting it here as a PR in case anyone else needs this setup.